### PR TITLE
fix: stack overflow when scanning large number of JSONL (SUPER TINY PR +1-1)

### DIFF
--- a/src/utils/usage-scanner.js
+++ b/src/utils/usage-scanner.js
@@ -147,7 +147,7 @@ export async function scanAllHistoricalUsage(showProgress = true) {
           cwd: claudeDir,
           absolute: true
         });
-        allFiles.push(...files);
+        for (const file of files) allFiles.push(file);
       } catch {
         // Skip paths that can't be accessed
       }


### PR DESCRIPTION
## Summary
  - Fix stack overflow error when users have 65k+ JSONL files in `~/.claude/projects`
  - Replace spread operator with for loop to avoid call stack limit

  ## Problem
  Users with many JSONL files (100k+) see "No usage history found" even though files exist.

  **Root cause:** `allFiles.push(...files)` causes "Maximum call stack size exceeded" when the array has more than ~65,536 elements. The catch block silently swallows this error, making it appear as if no files were found.

  ## Solution
  Replace the spread operator with a for loop:
  ```js
  // Before (causes stack overflow with large arrays)
  allFiles.push(...files);

  // After (safe for any array size)
  for (const file of files) allFiles.push(file);

  Testing

  Tested with 106,000+ JSONL files:
  - Before fix: "No usage history found"
  - After fix: "Found 145,074 usage entries" ✅