### PR TITLE
fix: skip zero-token entries to prevent sync failures

### DIFF
--- a/src/utils/usage-scanner.js
+++ b/src/utils/usage-scanner.js
@@ -21,11 +21,15 @@ function validateUsageData(data) {
     if (!data.timestamp) return false;
     if (!data.message || typeof data.message !== 'object') return false;
     if (!data.message.usage || typeof data.message.usage !== 'object') return false;
-    
+
     const usage = data.message.usage;
     // Must have both input_tokens and output_tokens as numbers
-    return typeof usage.input_tokens === 'number' && 
-           typeof usage.output_tokens === 'number';
+    if (typeof usage.input_tokens !== 'number' || typeof usage.output_tokens !== 'number') return false;
+
+    // Skip entries with zero total tokens (e.g. <synthetic> metadata)
+    const totalTokens = usage.input_tokens + usage.output_tokens
+      + (usage.cache_creation_input_tokens || 0) + (usage.cache_read_input_tokens || 0);
+    return totalTokens > 0;
   } catch {
     return false;
   }
@@ -56,12 +60,12 @@ function getClaudePaths() {
 function createUniqueHash(data) {
   const requestId = data.requestId;
   const messageId = data.message?.id;
-  
+
   // Match ccusage behavior: require BOTH messageId AND requestId
   if (requestId && messageId) {
     return `${messageId}:${requestId}`;
   }
-  
+
   // Return null if either is missing - these entries won't be deduplicated
   return null;
 }


### PR DESCRIPTION
## Summary
- Skip entries with zero total tokens in `validateUsageData()` instead of syncing them to the server
- These are error responses (e.g. billing errors, API failures) with no actual usage data

## Root Cause
The usage scanner included entries with zero tokens (model `<synthetic>`, `isApiErrorMessage: true`). These are Claude Code error responses, not real API usage. The server rejects them during bulk import, causing partial sync failures.

Example raw entry:
```json
{
  "model": "<synthetic>",
  "error": "billing_error",
  "isApiErrorMessage": true,
  "message": {
    "usage": {"input_tokens": 0, "output_tokens": 0},
    "content": [{"text": "Credit balance is too low"}]
  }
}
```

## Changes
- `src/utils/usage-scanner.js`: Filter by total token count (input + output + cache) > 0, not by model name

## Verification
Before fix:
```
✔ Found 18,249 usage entries
⚠ Synced 12,255 entries (5994 failed)
```

After fix:
```
✔ Found 17,902 usage entries
✔ Successfully imported 17,902 entries
```

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)